### PR TITLE
Add configurable OpenAI URL and Model

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -15,32 +15,32 @@ class LLM:
     """
     LLM Request
     {
-    	"original_user_request": ...,
-    	"step_num": ...,
-    	"screenshot": ...
+        "original_user_request": ...,
+        "step_num": ...,
+        "screenshot": ...
     }
 
     step_num is the count of times we've interacted with the LLM for this user request.
         If it's 0, we know it's a fresh user request.
-    	If it's greater than 0, then we know we are already in the middle of a request.
-    	Therefore, if the number is positive and from the screenshot it looks like request is complete, then return an
-    	    empty list in steps and a string in done. Don't keep looping the same request.
+        If it's greater than 0, then we know we are already in the middle of a request.
+        Therefore, if the number is positive and from the screenshot it looks like request is complete, then return an
+            empty list in steps and a string in done. Don't keep looping the same request.
 
     Expected LLM Response
     {
-    	"steps": [
-    		{
-    			"function": "...",
-    			"parameters": {
-    				"key1": "value1",
-    				...
-    			},
-    			"human_readable_justification": "..."
-    		},
-    		{...},
-    		...
-    	],
-    	"done": ...
+        "steps": [
+                {
+                        "function": "...",
+                        "parameters": {
+                                "key1": "value1",
+                                ...
+                        },
+                        "human_readable_justification": "..."
+                },
+                {...},
+                ...
+        ],
+        "done": ...
     }
 
     function is the function name to call in the executor.
@@ -63,50 +63,71 @@ class LLM:
 
     def __init__(self):
         settings_dict: dict[str, str] = Settings().get_dict()
-        if 'api_key' in settings_dict.keys() and settings_dict['api_key']:
-            os.environ["OPENAI_API_KEY"] = settings_dict['api_key']
-
-        path_to_context_file = Path(__file__).resolve().parent.joinpath('resources', 'context.txt')
-        with open(path_to_context_file, 'r') as file:
+        if "api_key" in settings_dict.keys() and settings_dict["api_key"]:
+            os.environ["OPENAI_API_KEY"] = settings_dict["api_key"]
+        base_url = "https://api.openai.com/v1/"
+        if "base_url" in settings_dict.keys() and settings_dict["base_url"]:
+            base_url = settings_dict["base_url"]
+        if not base_url.endswith("/"):
+            base_url += "/"
+        path_to_context_file = (
+            Path(__file__).resolve().parent.joinpath("resources", "context.txt")
+        )
+        with open(path_to_context_file, "r") as file:
             self.context = file.read()
 
         self.context += f' Locally installed apps are {",".join(local_info.locally_installed_apps)}.'
-        self.context += f' OS is {local_info.operating_system}.'
-        self.context += f' Primary screen size is {Screen().get_size()}.\n'
+        self.context += f" OS is {local_info.operating_system}."
+        self.context += f" Primary screen size is {Screen().get_size()}.\n"
 
-        if 'default_browser' in settings_dict.keys() and settings_dict['default_browser']:
+        if (
+            "default_browser" in settings_dict.keys()
+            and settings_dict["default_browser"]
+        ):
             self.context += f'\nDefault browser is {settings_dict["default_browser"]}.'
 
-        if 'custom_llm_instructions' in settings_dict:
-            self.context += f'\nCustom user-added info: {settings_dict["custom_llm_instructions"]}.'
+        if "custom_llm_instructions" in settings_dict:
+            self.context += (
+                f'\nCustom user-added info: {settings_dict["custom_llm_instructions"]}.'
+            )
 
-        self.client = OpenAI()
-        self.model = 'gpt-4-vision-preview'
+        self.client = OpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url=base_url)
+        self.model = (
+            settings_dict["model"]
+            if "model" in settings_dict
+            else "gpt-4-vision-preview"
+        )
 
-    def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
-        message: list[dict[str, Any]] = self.create_message_for_llm(original_user_request, step_num)
+    def get_instructions_for_objective(
+        self, original_user_request: str, step_num: int = 0
+    ) -> dict[str, Any]:
+        message: list[dict[str, Any]] = self.create_message_for_llm(
+            original_user_request, step_num
+        )
         llm_response = self.send_message_to_llm(message)
-        json_instructions: dict[str, Any] = self.convert_llm_response_to_json(llm_response)
+        json_instructions: dict[str, Any] = self.convert_llm_response_to_json(
+            llm_response
+        )
 
         return json_instructions
 
-    def create_message_for_llm(self, original_user_request, step_num) -> list[dict[str, Any]]:
+    def create_message_for_llm(
+        self, original_user_request, step_num
+    ) -> list[dict[str, Any]]:
         base64_img: str = Screen().get_screenshot_in_base64()
 
-        request_data: str = json.dumps({
-            'original_user_request': original_user_request,
-            'step_num': step_num
-        })
+        request_data: str = json.dumps(
+            {"original_user_request": original_user_request, "step_num": step_num}
+        )
 
         # We have to add context every request for now which is expensive because our chosen model doesn't have a
         #   stateful/Assistant mode yet.
         message = [
-            {'type': 'text', 'text': self.context + request_data},
-            {'type': 'image_url',
-             'image_url': {
-                 'url': f'data:image/jpeg;base64,{base64_img}'
-             }
-             }
+            {"type": "text", "text": self.context + request_data},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
+            },
         ]
 
         return message
@@ -116,26 +137,30 @@ class LLM:
             model=self.model,
             messages=[
                 {
-                    'role': 'user',
-                    'content': message,
+                    "role": "user",
+                    "content": message,
                 }
             ],
             max_tokens=800,
         )
         return response
 
-    def convert_llm_response_to_json(self, llm_response: ChatCompletion) -> dict[str, Any]:
+    def convert_llm_response_to_json(
+        self, llm_response: ChatCompletion
+    ) -> dict[str, Any]:
         llm_response_data: str = llm_response.choices[0].message.content.strip()
 
         # Our current LLM model does not guarantee a JSON response hence we manually parse the JSON part of the response
         # Check for updates here - https://platform.openai.com/docs/guides/text-generation/json-mode
-        start_index = llm_response_data.find('{')
-        end_index = llm_response_data.rfind('}')
+        start_index = llm_response_data.find("{")
+        end_index = llm_response_data.rfind("}")
 
         try:
-            json_response = json.loads(llm_response_data[start_index:end_index + 1].strip())
+            json_response = json.loads(
+                llm_response_data[start_index : end_index + 1].strip()
+            )
         except Exception as e:
-            print(f'Error while parsing JSON response - {e}')
+            print(f"Error while parsing JSON response - {e}")
             json_response = {}
 
         return json_response

--- a/app/llm.py
+++ b/app/llm.py
@@ -15,32 +15,32 @@ class LLM:
     """
     LLM Request
     {
-        "original_user_request": ...,
-        "step_num": ...,
-        "screenshot": ...
+    	"original_user_request": ...,
+    	"step_num": ...,
+    	"screenshot": ...
     }
 
     step_num is the count of times we've interacted with the LLM for this user request.
         If it's 0, we know it's a fresh user request.
-        If it's greater than 0, then we know we are already in the middle of a request.
-        Therefore, if the number is positive and from the screenshot it looks like request is complete, then return an
-            empty list in steps and a string in done. Don't keep looping the same request.
+    	If it's greater than 0, then we know we are already in the middle of a request.
+    	Therefore, if the number is positive and from the screenshot it looks like request is complete, then return an
+    	    empty list in steps and a string in done. Don't keep looping the same request.
 
     Expected LLM Response
     {
-        "steps": [
-                {
-                        "function": "...",
-                        "parameters": {
-                                "key1": "value1",
-                                ...
-                        },
-                        "human_readable_justification": "..."
-                },
-                {...},
-                ...
-        ],
-        "done": ...
+    	"steps": [
+    		{
+    			"function": "...",
+    			"parameters": {
+    				"key1": "value1",
+    				...
+    			},
+    			"human_readable_justification": "..."
+    		},
+    		{...},
+    		...
+    	],
+    	"done": ...
     }
 
     function is the function name to call in the executor.
@@ -63,71 +63,57 @@ class LLM:
 
     def __init__(self):
         settings_dict: dict[str, str] = Settings().get_dict()
-        if "api_key" in settings_dict.keys() and settings_dict["api_key"]:
-            os.environ["OPENAI_API_KEY"] = settings_dict["api_key"]
-        base_url = "https://api.openai.com/v1/"
-        if "base_url" in settings_dict.keys() and settings_dict["base_url"]:
-            base_url = settings_dict["base_url"]
-        if not base_url.endswith("/"):
-            base_url += "/"
-        path_to_context_file = (
-            Path(__file__).resolve().parent.joinpath("resources", "context.txt")
-        )
-        with open(path_to_context_file, "r") as file:
+
+        base_url = settings_dict.get('base_url', 'https://api.openai.com/v1/').rstrip('/') + '/'
+        api_key = settings_dict.get('api_key')
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key
+
+        path_to_context_file = Path(__file__).resolve().parent.joinpath('resources', 'context.txt')
+        with open(path_to_context_file, 'r') as file:
             self.context = file.read()
 
         self.context += f' Locally installed apps are {",".join(local_info.locally_installed_apps)}.'
-        self.context += f" OS is {local_info.operating_system}."
-        self.context += f" Primary screen size is {Screen().get_size()}.\n"
+        self.context += f' OS is {local_info.operating_system}.'
+        self.context += f' Primary screen size is {Screen().get_size()}.\n'
 
-        if (
-            "default_browser" in settings_dict.keys()
-            and settings_dict["default_browser"]
-        ):
+        if 'default_browser' in settings_dict.keys() and settings_dict['default_browser']:
             self.context += f'\nDefault browser is {settings_dict["default_browser"]}.'
 
-        if "custom_llm_instructions" in settings_dict:
-            self.context += (
-                f'\nCustom user-added info: {settings_dict["custom_llm_instructions"]}.'
-            )
+        if 'custom_llm_instructions' in settings_dict:
+            self.context += f'\nCustom user-added info: {settings_dict["custom_llm_instructions"]}.'
 
+        self.client = OpenAI()
+
+        self.model = settings_dict.get('model')
+        if not self.model:
+            self.model = 'gpt-4-vision-preview'
         self.client = OpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url=base_url)
-        self.model = (
-            settings_dict["model"]
-            if "model" in settings_dict
-            else "gpt-4-vision-preview"
-        )
 
-    def get_instructions_for_objective(
-        self, original_user_request: str, step_num: int = 0
-    ) -> dict[str, Any]:
-        message: list[dict[str, Any]] = self.create_message_for_llm(
-            original_user_request, step_num
-        )
+    def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
+        message: list[dict[str, Any]] = self.create_message_for_llm(original_user_request, step_num)
         llm_response = self.send_message_to_llm(message)
-        json_instructions: dict[str, Any] = self.convert_llm_response_to_json(
-            llm_response
-        )
+        json_instructions: dict[str, Any] = self.convert_llm_response_to_json(llm_response)
 
         return json_instructions
 
-    def create_message_for_llm(
-        self, original_user_request, step_num
-    ) -> list[dict[str, Any]]:
+    def create_message_for_llm(self, original_user_request, step_num) -> list[dict[str, Any]]:
         base64_img: str = Screen().get_screenshot_in_base64()
 
-        request_data: str = json.dumps(
-            {"original_user_request": original_user_request, "step_num": step_num}
-        )
+        request_data: str = json.dumps({
+            'original_user_request': original_user_request,
+            'step_num': step_num
+        })
 
         # We have to add context every request for now which is expensive because our chosen model doesn't have a
         #   stateful/Assistant mode yet.
         message = [
-            {"type": "text", "text": self.context + request_data},
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
-            },
+            {'type': 'text', 'text': self.context + request_data},
+            {'type': 'image_url',
+             'image_url': {
+                 'url': f'data:image/jpeg;base64,{base64_img}'
+             }
+             }
         ]
 
         return message
@@ -137,30 +123,26 @@ class LLM:
             model=self.model,
             messages=[
                 {
-                    "role": "user",
-                    "content": message,
+                    'role': 'user',
+                    'content': message,
                 }
             ],
             max_tokens=800,
         )
         return response
 
-    def convert_llm_response_to_json(
-        self, llm_response: ChatCompletion
-    ) -> dict[str, Any]:
+    def convert_llm_response_to_json(self, llm_response: ChatCompletion) -> dict[str, Any]:
         llm_response_data: str = llm_response.choices[0].message.content.strip()
 
         # Our current LLM model does not guarantee a JSON response hence we manually parse the JSON part of the response
         # Check for updates here - https://platform.openai.com/docs/guides/text-generation/json-mode
-        start_index = llm_response_data.find("{")
-        end_index = llm_response_data.rfind("}")
+        start_index = llm_response_data.find('{')
+        end_index = llm_response_data.rfind('}')
 
         try:
-            json_response = json.loads(
-                llm_response_data[start_index : end_index + 1].strip()
-            )
+            json_response = json.loads(llm_response_data[start_index:end_index + 1].strip())
         except Exception as e:
-            print(f"Error while parsing JSON response - {e}")
+            print(f'Error while parsing JSON response - {e}')
             json_response = {}
 
         return json_response

--- a/app/ui.py
+++ b/app/ui.py
@@ -26,6 +26,57 @@ class UI:
     def display_current_status(self, text: str):
         self.main_window.update_message(text)
 
+    class AdvancedSettingsWindow(tk.Toplevel):
+        """
+        Self-contained settings sub-window for the UI
+        """
+
+        def __init__(self, parent):
+            super().__init__(parent)
+            self.title('Advanced Settings')
+            self.minsize(300, 300)
+            self.create_widgets()
+            self.settings = Settings()
+
+            # Populate UI
+            settings_dict = self.settings.get_dict()
+
+            if 'base_url' in settings_dict:
+                self.base_url_entry.insert(0, settings_dict['base_url'])
+            if 'model' in settings_dict:
+                self.model_entry.insert(0, settings_dict['model'])
+
+        def create_widgets(self) -> None:
+            label_base_url = tk.Label(self, text='Custom OpenAI-Like API Model Base URL')
+            label_base_url.pack(pady=10)
+
+            # Entry for Base URL
+            self.base_url_entry = ttk.Entry(self, width=30)
+            self.base_url_entry.pack()
+
+            # Model Label
+            label_model = tk.Label(self, text='Custom Model Name:')
+            label_model.pack(pady=10)
+
+            # Entry for Model
+            self.model_entry = ttk.Entry(self, width=30)
+            self.model_entry.pack()
+
+            # Save Button
+            save_button = ttk.Button(self, text='Save Settings', command=self.save_button)
+            save_button.pack(pady=20)
+
+        def save_button(self) -> None:
+            base_url = self.base_url_entry.get().strip()
+            model = self.model_entry.get().strip()
+            settings_dict = {
+                "base_url": base_url,
+                "model": model,
+            }
+
+            self.settings.save_settings_to_file(settings_dict)
+            self.destroy()
+
     class SettingsWindow(tk.Toplevel):
         """
         Self-contained settings sub-window for the UI
@@ -33,7 +84,7 @@ class UI:
 
         def __init__(self, parent):
             super().__init__(parent)
-            self.title("Settings")
+            self.title('Settings')
             self.minsize(300, 450)
             self.create_widgets()
 
@@ -42,64 +93,37 @@ class UI:
             # Populate UI
             settings_dict = self.settings.get_dict()
 
-            if "api_key" in settings_dict:
-                self.api_key_entry.insert(0, settings_dict["api_key"])
-            if "default_browser" in settings_dict:
-                self.browser_combobox.set(settings_dict["default_browser"])
-            if "play_ding_on_completion" in settings_dict:
-                self.play_ding.set(1 if settings_dict["play_ding_on_completion"] else 0)
-            if "custom_llm_instructions" in settings_dict:
-                self.llm_instructions_text.insert(
-                    "1.0", settings_dict["custom_llm_instructions"]
-                )
+            if 'api_key' in settings_dict:
+                self.api_key_entry.insert(0, settings_dict['api_key'])
+            if 'default_browser' in settings_dict:
+                self.browser_combobox.set(settings_dict['default_browser'])
+            if 'play_ding_on_completion' in settings_dict:
+                self.play_ding.set(1 if settings_dict['play_ding_on_completion'] else 0)
+            if 'custom_llm_instructions' in settings_dict:
+                self.llm_instructions_text.insert('1.0', settings_dict['custom_llm_instructions'])
 
         def create_widgets(self) -> None:
             # Label for API Key
-            label_api = tk.Label(self, text="OpenAI API Key:")
+            label_api = tk.Label(self, text='OpenAI API Key:')
             label_api.pack(pady=10)
 
             # Entry for API Key
             self.api_key_entry = ttk.Entry(self, width=30)
             self.api_key_entry.pack()
 
-            # Label for Base URL, set default to https://api.openai.com/v1/
-            label_base_url = tk.Label(
-                self, text="OpenAI API: (Default: https://api.openai.com/v1/)"
-            )
-            label_base_url.pack(pady=10)
-
-            # Entry for Base URL
-            self.base_url_entry = ttk.Entry(self, width=30)
-            self.base_url_entry.pack()
-            self.base_url_entry.insert(0, "https://api.openai.com/v1/")
-
-            # Model Label
-            label_model = tk.Label(
-                self, text="OpenAI Model: (Default: gpt-4-vision-preview)"
-            )
-            label_model.pack(pady=10)
-
-            # Entry for Model
-            self.model_entry = ttk.Entry(self, width=30)
-            self.model_entry.pack()
-            self.model_entry.insert(0, "gpt-4-vision-preview")
-
             # Label for Browser Choice
-            label_browser = tk.Label(self, text="Choose Default Browser:")
+            label_browser = tk.Label(self, text='Choose Default Browser:')
             label_browser.pack(pady=10)
 
             # Dropdown for Browser Choice
             self.browser_var = tk.StringVar()
-            self.browser_combobox = ttk.Combobox(
-                self,
-                textvariable=self.browser_var,
-                values=["Safari", "Firefox", "Chrome"],
-            )
+            self.browser_combobox = ttk.Combobox(self, textvariable=self.browser_var,
+                                                 values=['Safari', 'Firefox', 'Chrome'])
             self.browser_combobox.pack(pady=5)
-            self.browser_combobox.set("Choose Browser")
+            self.browser_combobox.set('Choose Browser')
 
             # Label for Custom LLM Instructions
-            label_llm = tk.Label(self, text="Custom LLM Instructions:")
+            label_llm = tk.Label(self, text='Custom LLM Instructions:')
             label_llm.pack(pady=10)
 
             # Text Box for Custom LLM Instructions
@@ -108,76 +132,58 @@ class UI:
 
             # Checkbox for "Play Ding" option
             self.play_ding = tk.IntVar()
-            play_ding_checkbox = ttk.Checkbutton(
-                self, text="Play Ding on Completion", variable=self.play_ding
-            )
+            play_ding_checkbox = ttk.Checkbutton(self, text="Play Ding on Completion", variable=self.play_ding)
             play_ding_checkbox.pack(pady=10)
 
             # Save Button
-            save_button = ttk.Button(
-                self, text="Save Settings", command=self.save_button
-            )
-            save_button.pack(pady=20)
+            save_button = ttk.Button(self, text='Save Settings', command=self.save_button)
+            save_button.pack(pady=(10, 0))
+
+            # Button to open Advanced Settings
+            advanced_settings_button = ttk.Button(self, text='Advanced Settings', command=self.open_advanced_settings)
+            advanced_settings_button.pack(pady=(0, 10))
 
             # Hyperlink Label
-            link_label = tk.Label(self, text="Instructions", fg="#499CE4")
+            link_label = tk.Label(self, text='Instructions', fg='#499CE4')
             link_label.pack()
-            link_label.bind(
-                "<Button-1>",
-                lambda e: open_link(
-                    "https://github.com/AmberSahdev/Open-Interface?tab=readme-ov-file#setup-%EF%B8%8F"
-                ),
-            )
+            link_label.bind('<Button-1>', lambda e: open_link(
+                'https://github.com/AmberSahdev/Open-Interface?tab=readme-ov-file#setup-%EF%B8%8F'))
 
             # Version Label
-            version_label = tk.Label(
-                self, text=f"Version: {str(version)}", font=("Helvetica", 10)
-            )
+            version_label = tk.Label(self, text=f'Version: {str(version)}', font=('Helvetica', 10))
             version_label.pack(side="bottom", pady=10)
 
         def save_button(self) -> None:
             api_key = self.api_key_entry.get().strip()
             default_browser = self.browser_var.get()
-            base_url = self.base_url_entry.get().strip()
-            model = self.model_entry.get().strip()
-            if not base_url.endswith("/"):
-                base_url += "/"
             settings_dict = {
-                "api_key": api_key,
-                "base_url": base_url,
-                "model": model,
-                "default_browser": default_browser,
-                "play_ding_on_completion": bool(self.play_ding.get()),
-                "custom_llm_instructions": self.llm_instructions_text.get(
-                    "1.0", "end-1c"
-                ).strip(),
+                'api_key': api_key,
+                'default_browser': default_browser,
+                'play_ding_on_completion': bool(self.play_ding.get()),
+                'custom_llm_instructions': self.llm_instructions_text.get("1.0", "end-1c").strip()
             }
 
             self.settings.save_settings_to_file(settings_dict)
             self.destroy()
 
+        def open_advanced_settings(self):
+            # Open the advanced settings window
+            UI.AdvancedSettingsWindow(self)
+
     class MainWindow(tk.Tk):
         def __init__(self):
             super().__init__()
-            self.title("Open Interface")
+            self.title('Open Interface')
             self.minsize(420, 250)
 
             # PhotoImage object needs to persist as long as the app does, hence it's a class object.
-            path_to_icon_png = (
-                Path(__file__).resolve().parent.joinpath("resources", "icon.png")
-            )
-            path_to_microphone_png = (
-                Path(__file__).resolve().parent.joinpath("resources", "microphone.png")
-            )
-            self.logo_img = ImageTk.PhotoImage(
-                Image.open(path_to_icon_png).resize((50, 50))
-            )
-            self.mic_icon = ImageTk.PhotoImage(
-                Image.open(path_to_microphone_png).resize((18, 18))
-            )
+            path_to_icon_png = Path(__file__).resolve().parent.joinpath('resources', 'icon.png')
+            path_to_microphone_png = Path(__file__).resolve().parent.joinpath('resources', 'microphone.png')
+            self.logo_img = ImageTk.PhotoImage(Image.open(path_to_icon_png).resize((50, 50)))
+            self.mic_icon = ImageTk.PhotoImage(Image.open(path_to_microphone_png).resize((18, 18)))
 
             # This adds app icon in linux which pyinstaller can't
-            self.tk.call("wm", "iconphoto", self._w, self.logo_img)
+            self.tk.call('wm', 'iconphoto', self._w, self.logo_img)
 
             # MP Queue to facilitate communication between UI and Core.
             # Put user requests received from UI text box into this queue which will then be dequeued in App to be sent
@@ -189,7 +195,7 @@ class UI:
         def create_widgets(self) -> None:
             # Creates and arranges the UI elements
             # Frame
-            frame = ttk.Frame(self, padding="10 10 10 10")
+            frame = ttk.Frame(self, padding='10 10 10 10')
             frame.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
             frame.columnconfigure(0, weight=1)
 
@@ -197,12 +203,8 @@ class UI:
             logo_label.grid(column=0, row=0, sticky=tk.W, pady=(10, 20))
 
             # Heading Label
-            heading_label = tk.Label(
-                frame,
-                text="What would you like me to do?",
-                font=("Helvetica", 16),
-                wraplength=400,
-            )
+            heading_label = tk.Label(frame, text='What would you like me to do?', font=('Helvetica', 16),
+                                     wraplength=400)
             heading_label.grid(column=0, row=1, columnspan=3, sticky=tk.W)
 
             # Entry widget
@@ -210,39 +212,28 @@ class UI:
             self.entry.grid(column=0, row=2, sticky=(tk.W, tk.E))
 
             # Submit Button
-            button = ttk.Button(frame, text="Submit", command=self.execute_user_request)
+            button = ttk.Button(frame, text='Submit', command=self.execute_user_request)
             button.grid(column=2, row=2)
 
             # Mic Button
-            mic_button = tk.Button(
-                frame,
-                image=self.mic_icon,
-                command=self.start_voice_input_thread,
-                borderwidth=0,
-                highlightthickness=0,
-            )
+            mic_button = tk.Button(frame, image=self.mic_icon, command=self.start_voice_input_thread, borderwidth=0,
+                                   highlightthickness=0)
             mic_button.grid(column=1, row=2, padx=(0, 5))
 
             # Settings Button
-            settings_button = ttk.Button(
-                self, text="Settings", command=self.open_settings
-            )
-            settings_button.place(relx=1.0, rely=0.0, anchor="ne", x=-5, y=5)
+            settings_button = ttk.Button(self, text='Settings', command=self.open_settings)
+            settings_button.place(relx=1.0, rely=0.0, anchor='ne', x=-5, y=5)
 
             # Stop Button
-            stop_button = ttk.Button(
-                self, text="Stop", command=self.stop_previous_request
-            )
-            stop_button.place(relx=1.0, rely=1.0, anchor="se", x=-10, y=-10)
+            stop_button = ttk.Button(self, text='Stop', command=self.stop_previous_request)
+            stop_button.place(relx=1.0, rely=1.0, anchor='se', x=-10, y=-10)
 
             # Text display for echoed input
-            self.input_display = tk.Label(
-                frame, text="", font=("Helvetica", 16), wraplength=400
-            )
+            self.input_display = tk.Label(frame, text='', font=('Helvetica', 16), wraplength=400)
             self.input_display.grid(column=0, row=3, columnspan=3, sticky=tk.W)
 
             # Text display for additional messages
-            self.message_display = tk.Label(frame, text="", font=("Helvetica", 14))
+            self.message_display = tk.Label(frame, text='', font=('Helvetica', 14))
             self.message_display.grid(column=0, row=6, columnspan=3, sticky=tk.W)
 
         def open_settings(self) -> None:
@@ -250,12 +241,12 @@ class UI:
 
         def stop_previous_request(self) -> None:
             # Interrupt currently running request by queueing a stop signal.
-            self.user_request_queue.put("stop")
+            self.user_request_queue.put('stop')
 
         def display_input(self) -> str:
             # Get the entry and update the input display
             user_input = self.entry.get()
-            self.input_display["text"] = f"{user_input}"
+            self.input_display['text'] = f'{user_input}'
 
             # Clear the entry widget
             self.entry.delete(0, tk.END)
@@ -266,10 +257,10 @@ class UI:
             # Puts the user request received from the UI into the MP queue being read in App to be sent to Core.
             user_request = self.display_input()
 
-            if user_request == "" or user_request is None:
+            if user_request == '' or user_request is None:
                 return
 
-            self.update_message("Fetching Instructions")
+            self.update_message('Fetching Instructions')
 
             self.user_request_queue.put(user_request)
 
@@ -281,27 +272,25 @@ class UI:
             # Function to handle voice input
             recognizer = sr.Recognizer()
             with sr.Microphone() as source:
-                self.update_message("Listening...")
+                self.update_message('Listening...')
                 try:
                     audio = recognizer.listen(source, timeout=4)
                     try:
                         text = recognizer.recognize_google(audio)
                         self.entry.delete(0, tk.END)
                         self.entry.insert(0, text)
-                        self.update_message("")
+                        self.update_message('')
                     except sr.UnknownValueError:
-                        self.update_message("Could not understand audio")
+                        self.update_message('Could not understand audio')
                     except sr.RequestError as e:
-                        self.update_message(f"Could not request results - {e}")
+                        self.update_message(f'Could not request results - {e}')
                 except sr.WaitTimeoutError:
-                    self.update_message("Didn't hear anything")
+                    self.update_message('Didn\'t hear anything')
 
         def update_message(self, message: str) -> None:
             # Update the message display with the provided text.
             # Ensure thread safety when updating the Tkinter GUI.
             if threading.current_thread() is threading.main_thread():
-                self.message_display["text"] = message
+                self.message_display['text'] = message
             else:
-                self.message_display.after(
-                    0, lambda: self.message_display.config(text=message)
-                )
+                self.message_display.after(0, lambda: self.message_display.config(text=message))

--- a/app/ui.py
+++ b/app/ui.py
@@ -33,7 +33,7 @@ class UI:
 
         def __init__(self, parent):
             super().__init__(parent)
-            self.title('Settings')
+            self.title("Settings")
             self.minsize(300, 450)
             self.create_widgets()
 
@@ -42,37 +42,64 @@ class UI:
             # Populate UI
             settings_dict = self.settings.get_dict()
 
-            if 'api_key' in settings_dict:
-                self.api_key_entry.insert(0, settings_dict['api_key'])
-            if 'default_browser' in settings_dict:
-                self.browser_combobox.set(settings_dict['default_browser'])
-            if 'play_ding_on_completion' in settings_dict:
-                self.play_ding.set(1 if settings_dict['play_ding_on_completion'] else 0)
-            if 'custom_llm_instructions' in settings_dict:
-                self.llm_instructions_text.insert('1.0', settings_dict['custom_llm_instructions'])
+            if "api_key" in settings_dict:
+                self.api_key_entry.insert(0, settings_dict["api_key"])
+            if "default_browser" in settings_dict:
+                self.browser_combobox.set(settings_dict["default_browser"])
+            if "play_ding_on_completion" in settings_dict:
+                self.play_ding.set(1 if settings_dict["play_ding_on_completion"] else 0)
+            if "custom_llm_instructions" in settings_dict:
+                self.llm_instructions_text.insert(
+                    "1.0", settings_dict["custom_llm_instructions"]
+                )
 
         def create_widgets(self) -> None:
             # Label for API Key
-            label_api = tk.Label(self, text='OpenAI API Key:')
+            label_api = tk.Label(self, text="OpenAI API Key:")
             label_api.pack(pady=10)
 
             # Entry for API Key
             self.api_key_entry = ttk.Entry(self, width=30)
             self.api_key_entry.pack()
 
+            # Label for Base URL, set default to https://api.openai.com/v1/
+            label_base_url = tk.Label(
+                self, text="OpenAI API: (Default: https://api.openai.com/v1/)"
+            )
+            label_base_url.pack(pady=10)
+
+            # Entry for Base URL
+            self.base_url_entry = ttk.Entry(self, width=30)
+            self.base_url_entry.pack()
+            self.base_url_entry.insert(0, "https://api.openai.com/v1/")
+
+            # Model Label
+            label_model = tk.Label(
+                self, text="OpenAI Model: (Default: gpt-4-vision-preview)"
+            )
+            label_model.pack(pady=10)
+
+            # Entry for Model
+            self.model_entry = ttk.Entry(self, width=30)
+            self.model_entry.pack()
+            self.model_entry.insert(0, "gpt-4-vision-preview")
+
             # Label for Browser Choice
-            label_browser = tk.Label(self, text='Choose Default Browser:')
+            label_browser = tk.Label(self, text="Choose Default Browser:")
             label_browser.pack(pady=10)
 
             # Dropdown for Browser Choice
             self.browser_var = tk.StringVar()
-            self.browser_combobox = ttk.Combobox(self, textvariable=self.browser_var,
-                                                 values=['Safari', 'Firefox', 'Chrome'])
+            self.browser_combobox = ttk.Combobox(
+                self,
+                textvariable=self.browser_var,
+                values=["Safari", "Firefox", "Chrome"],
+            )
             self.browser_combobox.pack(pady=5)
-            self.browser_combobox.set('Choose Browser')
+            self.browser_combobox.set("Choose Browser")
 
             # Label for Custom LLM Instructions
-            label_llm = tk.Label(self, text='Custom LLM Instructions:')
+            label_llm = tk.Label(self, text="Custom LLM Instructions:")
             label_llm.pack(pady=10)
 
             # Text Box for Custom LLM Instructions
@@ -81,31 +108,49 @@ class UI:
 
             # Checkbox for "Play Ding" option
             self.play_ding = tk.IntVar()
-            play_ding_checkbox = ttk.Checkbutton(self, text="Play Ding on Completion", variable=self.play_ding)
+            play_ding_checkbox = ttk.Checkbutton(
+                self, text="Play Ding on Completion", variable=self.play_ding
+            )
             play_ding_checkbox.pack(pady=10)
 
             # Save Button
-            save_button = ttk.Button(self, text='Save Settings', command=self.save_button)
+            save_button = ttk.Button(
+                self, text="Save Settings", command=self.save_button
+            )
             save_button.pack(pady=20)
 
             # Hyperlink Label
-            link_label = tk.Label(self, text='Instructions', fg='#499CE4')
+            link_label = tk.Label(self, text="Instructions", fg="#499CE4")
             link_label.pack()
-            link_label.bind('<Button-1>', lambda e: open_link(
-                'https://github.com/AmberSahdev/Open-Interface?tab=readme-ov-file#setup-%EF%B8%8F'))
+            link_label.bind(
+                "<Button-1>",
+                lambda e: open_link(
+                    "https://github.com/AmberSahdev/Open-Interface?tab=readme-ov-file#setup-%EF%B8%8F"
+                ),
+            )
 
             # Version Label
-            version_label = tk.Label(self, text=f'Version: {str(version)}', font=('Helvetica', 10))
+            version_label = tk.Label(
+                self, text=f"Version: {str(version)}", font=("Helvetica", 10)
+            )
             version_label.pack(side="bottom", pady=10)
 
         def save_button(self) -> None:
             api_key = self.api_key_entry.get().strip()
             default_browser = self.browser_var.get()
+            base_url = self.base_url_entry.get().strip()
+            model = self.model_entry.get().strip()
+            if not base_url.endswith("/"):
+                base_url += "/"
             settings_dict = {
-                'api_key': api_key,
-                'default_browser': default_browser,
-                'play_ding_on_completion': bool(self.play_ding.get()),
-                'custom_llm_instructions': self.llm_instructions_text.get("1.0", "end-1c").strip()
+                "api_key": api_key,
+                "base_url": base_url,
+                "model": model,
+                "default_browser": default_browser,
+                "play_ding_on_completion": bool(self.play_ding.get()),
+                "custom_llm_instructions": self.llm_instructions_text.get(
+                    "1.0", "end-1c"
+                ).strip(),
             }
 
             self.settings.save_settings_to_file(settings_dict)
@@ -114,17 +159,25 @@ class UI:
     class MainWindow(tk.Tk):
         def __init__(self):
             super().__init__()
-            self.title('Open Interface')
+            self.title("Open Interface")
             self.minsize(420, 250)
 
             # PhotoImage object needs to persist as long as the app does, hence it's a class object.
-            path_to_icon_png = Path(__file__).resolve().parent.joinpath('resources', 'icon.png')
-            path_to_microphone_png = Path(__file__).resolve().parent.joinpath('resources', 'microphone.png')
-            self.logo_img = ImageTk.PhotoImage(Image.open(path_to_icon_png).resize((50, 50)))
-            self.mic_icon = ImageTk.PhotoImage(Image.open(path_to_microphone_png).resize((18, 18)))
+            path_to_icon_png = (
+                Path(__file__).resolve().parent.joinpath("resources", "icon.png")
+            )
+            path_to_microphone_png = (
+                Path(__file__).resolve().parent.joinpath("resources", "microphone.png")
+            )
+            self.logo_img = ImageTk.PhotoImage(
+                Image.open(path_to_icon_png).resize((50, 50))
+            )
+            self.mic_icon = ImageTk.PhotoImage(
+                Image.open(path_to_microphone_png).resize((18, 18))
+            )
 
             # This adds app icon in linux which pyinstaller can't
-            self.tk.call('wm', 'iconphoto', self._w, self.logo_img)
+            self.tk.call("wm", "iconphoto", self._w, self.logo_img)
 
             # MP Queue to facilitate communication between UI and Core.
             # Put user requests received from UI text box into this queue which will then be dequeued in App to be sent
@@ -136,7 +189,7 @@ class UI:
         def create_widgets(self) -> None:
             # Creates and arranges the UI elements
             # Frame
-            frame = ttk.Frame(self, padding='10 10 10 10')
+            frame = ttk.Frame(self, padding="10 10 10 10")
             frame.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
             frame.columnconfigure(0, weight=1)
 
@@ -144,8 +197,12 @@ class UI:
             logo_label.grid(column=0, row=0, sticky=tk.W, pady=(10, 20))
 
             # Heading Label
-            heading_label = tk.Label(frame, text='What would you like me to do?', font=('Helvetica', 16),
-                                     wraplength=400)
+            heading_label = tk.Label(
+                frame,
+                text="What would you like me to do?",
+                font=("Helvetica", 16),
+                wraplength=400,
+            )
             heading_label.grid(column=0, row=1, columnspan=3, sticky=tk.W)
 
             # Entry widget
@@ -153,28 +210,39 @@ class UI:
             self.entry.grid(column=0, row=2, sticky=(tk.W, tk.E))
 
             # Submit Button
-            button = ttk.Button(frame, text='Submit', command=self.execute_user_request)
+            button = ttk.Button(frame, text="Submit", command=self.execute_user_request)
             button.grid(column=2, row=2)
 
             # Mic Button
-            mic_button = tk.Button(frame, image=self.mic_icon, command=self.start_voice_input_thread, borderwidth=0,
-                                   highlightthickness=0)
+            mic_button = tk.Button(
+                frame,
+                image=self.mic_icon,
+                command=self.start_voice_input_thread,
+                borderwidth=0,
+                highlightthickness=0,
+            )
             mic_button.grid(column=1, row=2, padx=(0, 5))
 
             # Settings Button
-            settings_button = ttk.Button(self, text='Settings', command=self.open_settings)
-            settings_button.place(relx=1.0, rely=0.0, anchor='ne', x=-5, y=5)
+            settings_button = ttk.Button(
+                self, text="Settings", command=self.open_settings
+            )
+            settings_button.place(relx=1.0, rely=0.0, anchor="ne", x=-5, y=5)
 
             # Stop Button
-            stop_button = ttk.Button(self, text='Stop', command=self.stop_previous_request)
-            stop_button.place(relx=1.0, rely=1.0, anchor='se', x=-10, y=-10)
+            stop_button = ttk.Button(
+                self, text="Stop", command=self.stop_previous_request
+            )
+            stop_button.place(relx=1.0, rely=1.0, anchor="se", x=-10, y=-10)
 
             # Text display for echoed input
-            self.input_display = tk.Label(frame, text='', font=('Helvetica', 16), wraplength=400)
+            self.input_display = tk.Label(
+                frame, text="", font=("Helvetica", 16), wraplength=400
+            )
             self.input_display.grid(column=0, row=3, columnspan=3, sticky=tk.W)
 
             # Text display for additional messages
-            self.message_display = tk.Label(frame, text='', font=('Helvetica', 14))
+            self.message_display = tk.Label(frame, text="", font=("Helvetica", 14))
             self.message_display.grid(column=0, row=6, columnspan=3, sticky=tk.W)
 
         def open_settings(self) -> None:
@@ -182,12 +250,12 @@ class UI:
 
         def stop_previous_request(self) -> None:
             # Interrupt currently running request by queueing a stop signal.
-            self.user_request_queue.put('stop')
+            self.user_request_queue.put("stop")
 
         def display_input(self) -> str:
             # Get the entry and update the input display
             user_input = self.entry.get()
-            self.input_display['text'] = f'{user_input}'
+            self.input_display["text"] = f"{user_input}"
 
             # Clear the entry widget
             self.entry.delete(0, tk.END)
@@ -198,10 +266,10 @@ class UI:
             # Puts the user request received from the UI into the MP queue being read in App to be sent to Core.
             user_request = self.display_input()
 
-            if user_request == '' or user_request is None:
+            if user_request == "" or user_request is None:
                 return
 
-            self.update_message('Fetching Instructions')
+            self.update_message("Fetching Instructions")
 
             self.user_request_queue.put(user_request)
 
@@ -213,25 +281,27 @@ class UI:
             # Function to handle voice input
             recognizer = sr.Recognizer()
             with sr.Microphone() as source:
-                self.update_message('Listening...')
+                self.update_message("Listening...")
                 try:
                     audio = recognizer.listen(source, timeout=4)
                     try:
                         text = recognizer.recognize_google(audio)
                         self.entry.delete(0, tk.END)
                         self.entry.insert(0, text)
-                        self.update_message('')
+                        self.update_message("")
                     except sr.UnknownValueError:
-                        self.update_message('Could not understand audio')
+                        self.update_message("Could not understand audio")
                     except sr.RequestError as e:
-                        self.update_message(f'Could not request results - {e}')
+                        self.update_message(f"Could not request results - {e}")
                 except sr.WaitTimeoutError:
-                    self.update_message('Didn\'t hear anything')
+                    self.update_message("Didn't hear anything")
 
         def update_message(self, message: str) -> None:
             # Update the message display with the provided text.
             # Ensure thread safety when updating the Tkinter GUI.
             if threading.current_thread() is threading.main_thread():
-                self.message_display['text'] = message
+                self.message_display["text"] = message
             else:
-                self.message_display.after(0, lambda: self.message_display.config(text=message))
+                self.message_display.after(
+                    0, lambda: self.message_display.config(text=message)
+                )

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -16,6 +16,7 @@ class Settings:
     def save_settings_to_file(self, settings_dict) -> None:
         settings: dict[str, str] = {}
 
+        # Preserve previous settings in case new dict doesn't contain them
         if os.path.exists(self.settings_file_path):
             with open(self.settings_file_path, 'r') as file:
                 try:


### PR DESCRIPTION
Excellent work on this project! I was working on building this same functionality when I started thinking that it might be better to check around, so I stumbled upon your project.

I wanted to add that a configurable OpenAI URL and Model would be useful for those of us using local models often. This will enable people to test vision models like deepseek-7b-vl-chat with [ezlocalai](https://github.com/DevXT-LLC/ezlocalai) or any other service that has OpenAI style endpoints and supports locally running vision models.  Results may vary just as with gpt-4-vision, but this opens the doors to attempting with models other than that one.

Apologies for my automatic black lint formatter making additional changes.