### PR TITLE
Add MiniMax as LLM provider (M2.7 + M2.5-highspeed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Control Your Computer Using LLMs
 
 Open Interface
-- Self-drives your computer by sending your requests to an LLM backend (GPT-4o, Gemini, etc) to figure out the required steps.
+- Self-drives your computer by sending your requests to an LLM backend (GPT-4o, Gemini, MiniMax, etc) to figure out the required steps.
 - Automatically executes these steps by simulating keyboard and mouse input.
 - Course-corrects by sending the LLM backend updated screenshots of the progress as needed.
 
@@ -169,6 +169,17 @@ Open Interface
 - Get your Google Gemini API key from https://aistudio.google.com/app/apikey.
 - Save the API key in Open Interface settings.
 - Save the settings and <b>restart the app</b>.
+
+</details>
+
+<details>
+    <summary><b>Set up the MiniMax API key</b></summary>
+
+- Go to Settings -> Advanced Settings and select the MiniMax model you wish to use (MiniMax-M2.7 or MiniMax-M2.5-highspeed).
+- Get your MiniMax API key from https://platform.minimaxi.com/
+- Save the API key in Open Interface settings.
+- Save the settings and **restart the app**.
+- Alternatively, set the `MINIMAX_API_KEY` environment variable and the API key will be auto-detected.
 
 </details>
 

--- a/app/models/factory.py
+++ b/app/models/factory.py
@@ -1,6 +1,7 @@
 from models.gpt4o import GPT4o
 from models.gpt4v import GPT4v
 from models.gpt5 import GPT5
+from models.minimax import MiniMax
 from models.openai_computer_use import OpenAIComputerUse
 from models.gemini import Gemini
 
@@ -19,6 +20,8 @@ class ModelFactory:
                 return GPT4v(model_name, *args)
             elif model_name.startswith("gemini"):
                 return Gemini(model_name, *args[1:])
+            elif model_name.startswith("MiniMax"):
+                return MiniMax(model_name, *args)
             else:
                 # Llama/Llava models will work with the standard code I wrote for GPT4V without the assitant mode features of gpt4o
                 return GPT4v(model_name, *args)

--- a/app/models/minimax.py
+++ b/app/models/minimax.py
@@ -1,0 +1,87 @@
+import json
+import os
+from typing import Any
+
+from models.model import Model
+from utils.screen import Screen
+
+MINIMAX_BASE_URL = 'https://api.minimax.io/v1/'
+
+
+class MiniMax(Model):
+    """
+    MiniMax model integration via OpenAI-compatible API.
+    Supports MiniMax-M2.7 (latest) and MiniMax-M2.5-highspeed (204K context).
+    """
+
+    def __init__(self, model_name, base_url, api_key, context):
+        # Use MiniMax base URL unless user has explicitly set a custom one
+        if not base_url or base_url.rstrip('/') + '/' == 'https://api.openai.com/v1/':
+            base_url = MINIMAX_BASE_URL
+
+        # Prefer MINIMAX_API_KEY env var if no API key was provided
+        if not api_key:
+            api_key = os.environ.get('MINIMAX_API_KEY', '')
+
+        super().__init__(model_name, base_url, api_key, context)
+
+        if api_key:
+            os.environ['MINIMAX_API_KEY'] = api_key
+
+    def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
+        message: list[dict[str, Any]] = self.format_user_request_for_llm(original_user_request, step_num)
+        llm_response = self.send_message_to_llm(message)
+        json_instructions: dict[str, Any] = self.convert_llm_response_to_json_instructions(llm_response)
+        return json_instructions
+
+    def format_user_request_for_llm(self, original_user_request, step_num) -> list[dict[str, Any]]:
+        base64_img: str = Screen().get_screenshot_in_base64()
+
+        request_data: str = json.dumps({
+            'original_user_request': original_user_request,
+            'step_num': step_num
+        })
+
+        message = [
+            {'type': 'text', 'text': self.context + request_data},
+            {'type': 'image_url',
+             'image_url': {
+                 'url': f'data:image/jpeg;base64,{base64_img}'
+             }
+             }
+        ]
+
+        return message
+
+    def send_message_to_llm(self, message):
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[
+                {
+                    'role': 'user',
+                    'content': message,
+                }
+            ],
+            max_tokens=800,
+            temperature=min(max(0.01, 0.7), 1.0),
+        )
+        return response
+
+    def convert_llm_response_to_json_instructions(self, llm_response) -> dict[str, Any]:
+        llm_response_data: str = llm_response.choices[0].message.content.strip()
+
+        # Strip MiniMax thinking tags if present (M2.5+ models may include <think>...</think> blocks)
+        if '<think>' in llm_response_data and '</think>' in llm_response_data:
+            think_end = llm_response_data.rfind('</think>')
+            llm_response_data = llm_response_data[think_end + len('</think>'):].strip()
+
+        start_index = llm_response_data.find('{')
+        end_index = llm_response_data.rfind('}')
+
+        try:
+            json_response = json.loads(llm_response_data[start_index:end_index + 1].strip())
+        except Exception as e:
+            print(f'Error while parsing JSON response - {e}')
+            json_response = {}
+
+        return json_response

--- a/app/ui.py
+++ b/app/ui.py
@@ -69,6 +69,11 @@ class UI:
                 ('Gemini gemini-3-flash-preview', 'gemini-3-flash-preview'),
             ]
 
+            minimax_models = [
+                ('MiniMax-M2.7 (1M Context)', 'MiniMax-M2.7'),
+                ('MiniMax-M2.5-highspeed (204K, Fast)', 'MiniMax-M2.5-highspeed'),
+            ]
+
             deprecated_models = [
                 ('GPT-4o (Medium-Accurate, Medium-Fast)', 'gpt-4o'),
                 ('GPT-4o-mini (Cheapest, Fastest)', 'gpt-4o-mini'),
@@ -90,6 +95,12 @@ class UI:
             ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
 
             for text, value in gemini_models:
+                ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
+                    anchor=ttk.W, pady=5)
+
+            ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
+
+            for text, value in minimax_models:
                 ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
                     anchor=ttk.W, pady=5)
 
@@ -192,7 +203,7 @@ class UI:
 
         def create_widgets(self) -> None:
             # API Key Widgets
-            label_api = ttk.Label(self, text='OpenAI/Gemini/LLM Model API Key:', bootstyle="info")
+            label_api = ttk.Label(self, text='OpenAI/Gemini/MiniMax/LLM Model API Key:', bootstyle="info")
             label_api.pack(pady=10)
             self.api_key_entry = ttk.Entry(self, width=30)
             self.api_key_entry.pack()

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,0 +1,393 @@
+"""Unit and integration tests for MiniMax model provider."""
+import json
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add app directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app')))
+
+# Mock pyautogui and related GUI modules before any model imports
+# These modules require X11 display which is unavailable in headless CI environments
+_mock_pyautogui = MagicMock()
+_mock_mouseinfo = MagicMock()
+_mock_screen_module = types.ModuleType('utils.screen')
+_mock_screen_module.Screen = MagicMock()
+
+sys.modules['pyautogui'] = _mock_pyautogui
+sys.modules['mouseinfo'] = _mock_mouseinfo
+sys.modules['utils.screen'] = _mock_screen_module
+
+# Mock google.genai to avoid pydantic v2 import issues in Gemini model
+_mock_genai = MagicMock()
+sys.modules['google'] = MagicMock()
+sys.modules['google.genai'] = _mock_genai
+sys.modules['google.genai.types'] = MagicMock()
+
+from openai import OpenAI  # noqa: E402
+
+
+class TestMiniMaxModel(unittest.TestCase):
+    """Unit tests for the MiniMax model class."""
+
+    def _create_minimax(self, model_name='MiniMax-M2.7', base_url='', api_key='test-key',
+                        context='test context'):
+        with patch('models.model.OpenAI') as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+            from models.minimax import MiniMax
+            model = MiniMax(model_name, base_url, api_key, context)
+            return model, mock_client, mock_openai_cls
+
+    def test_default_base_url(self):
+        """MiniMax model should use MiniMax base URL by default."""
+        model, _, mock_openai_cls = self._create_minimax()
+        call_args = mock_openai_cls.call_args
+        self.assertEqual(call_args[1]['base_url'], 'https://api.minimax.io/v1/')
+
+    def test_custom_base_url_preserved(self):
+        """Custom non-OpenAI base URL should be preserved."""
+        model, _, mock_openai_cls = self._create_minimax(
+            base_url='https://custom-proxy.example.com/v1/')
+        call_args = mock_openai_cls.call_args
+        self.assertEqual(call_args[1]['base_url'], 'https://custom-proxy.example.com/v1/')
+
+    def test_openai_default_url_overridden(self):
+        """OpenAI default URL should be overridden to MiniMax URL."""
+        model, _, mock_openai_cls = self._create_minimax(
+            base_url='https://api.openai.com/v1/')
+        call_args = mock_openai_cls.call_args
+        self.assertEqual(call_args[1]['base_url'], 'https://api.minimax.io/v1/')
+
+    def test_api_key_set(self):
+        """API key should be passed to OpenAI client."""
+        model, _, mock_openai_cls = self._create_minimax(api_key='my-minimax-key')
+        call_args = mock_openai_cls.call_args
+        self.assertEqual(call_args[1]['api_key'], 'my-minimax-key')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'env-api-key'})
+    def test_api_key_from_env(self):
+        """API key should fall back to MINIMAX_API_KEY env var."""
+        model, _, mock_openai_cls = self._create_minimax(api_key='')
+        call_args = mock_openai_cls.call_args
+        self.assertEqual(call_args[1]['api_key'], 'env-api-key')
+
+    def test_model_name(self):
+        """Model name should be stored correctly."""
+        model, _, _ = self._create_minimax(model_name='MiniMax-M2.5-highspeed')
+        self.assertEqual(model.model_name, 'MiniMax-M2.5-highspeed')
+
+    def test_context_stored(self):
+        """Context should be stored."""
+        model, _, _ = self._create_minimax(context='You are a helpful assistant.')
+        self.assertEqual(model.context, 'You are a helpful assistant.')
+
+    def test_format_user_request(self):
+        """format_user_request_for_llm should return text + image_url content."""
+        model, _, _ = self._create_minimax()
+
+        # Patch Screen at the module level where it's already imported
+        from models import minimax as minimax_mod
+        orig_screen = minimax_mod.Screen
+        mock_screen_cls = MagicMock()
+        mock_screen_cls.return_value.get_screenshot_in_base64.return_value = 'base64data'
+        minimax_mod.Screen = mock_screen_cls
+
+        try:
+            result = model.format_user_request_for_llm('open chrome', 0)
+
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0]['type'], 'text')
+            self.assertIn('open chrome', result[0]['text'])
+            self.assertEqual(result[1]['type'], 'image_url')
+            self.assertIn('base64data', result[1]['image_url']['url'])
+        finally:
+            minimax_mod.Screen = orig_screen
+
+    def test_send_message_temperature(self):
+        """send_message_to_llm should clamp temperature within (0, 1]."""
+        model, mock_client, _ = self._create_minimax()
+        model.send_message_to_llm([{'type': 'text', 'text': 'hello'}])
+
+        call_args = mock_client.chat.completions.create.call_args
+        temp = call_args[1]['temperature']
+        self.assertGreater(temp, 0)
+        self.assertLessEqual(temp, 1.0)
+
+    def test_send_message_max_tokens(self):
+        """send_message_to_llm should set max_tokens=800."""
+        model, mock_client, _ = self._create_minimax()
+        model.send_message_to_llm([{'type': 'text', 'text': 'test'}])
+
+        call_args = mock_client.chat.completions.create.call_args
+        self.assertEqual(call_args[1]['max_tokens'], 800)
+
+    def test_send_message_model_name(self):
+        """send_message_to_llm should use the correct model name."""
+        model, mock_client, _ = self._create_minimax(model_name='MiniMax-M2.5-highspeed')
+        model.send_message_to_llm([{'type': 'text', 'text': 'test'}])
+
+        call_args = mock_client.chat.completions.create.call_args
+        self.assertEqual(call_args[1]['model'], 'MiniMax-M2.5-highspeed')
+
+    def test_convert_json_response(self):
+        """convert_llm_response_to_json_instructions should parse JSON from response."""
+        model, _, _ = self._create_minimax()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            'steps': [{'function': 'click', 'parameters': {'x': 100, 'y': 200}}],
+            'done': None
+        })
+
+        result = model.convert_llm_response_to_json_instructions(mock_response)
+        self.assertIn('steps', result)
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0]['function'], 'click')
+
+    def test_convert_json_with_extra_text(self):
+        """Should extract JSON even when surrounded by extra text."""
+        model, _, _ = self._create_minimax()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Here is my plan:\n{"steps": [], "done": "Task complete"}\nEnd.'
+
+        result = model.convert_llm_response_to_json_instructions(mock_response)
+        self.assertEqual(result['done'], 'Task complete')
+        self.assertEqual(result['steps'], [])
+
+    def test_convert_json_strips_think_tags(self):
+        """Should strip <think>...</think> tags from MiniMax thinking models."""
+        model, _, _ = self._create_minimax()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '<think>Let me analyze the screenshot...</think>\n'
+            '{"steps": [{"function": "press", "parameters": {"key": "enter"}}], "done": null}'
+        )
+
+        result = model.convert_llm_response_to_json_instructions(mock_response)
+        self.assertIn('steps', result)
+        self.assertEqual(result['steps'][0]['function'], 'press')
+
+    def test_convert_json_handles_parse_error(self):
+        """Should return empty dict on malformed JSON."""
+        model, _, _ = self._create_minimax()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'No JSON here at all.'
+
+        result = model.convert_llm_response_to_json_instructions(mock_response)
+        self.assertEqual(result, {})
+
+    def test_convert_json_nested_think_tags(self):
+        """Should handle multiple or nested think tag blocks."""
+        model, _, _ = self._create_minimax()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '<think>first thought</think>\n'
+            '<think>second thought</think>\n'
+            '{"steps": [], "done": "completed"}'
+        )
+
+        result = model.convert_llm_response_to_json_instructions(mock_response)
+        self.assertEqual(result['done'], 'completed')
+
+    def test_cleanup(self):
+        """cleanup should not raise."""
+        model, _, _ = self._create_minimax()
+        model.cleanup()
+
+    def test_env_var_set_on_init(self):
+        """MINIMAX_API_KEY env var should be set when API key is provided."""
+        model, _, _ = self._create_minimax(api_key='test-env-key')
+        self.assertEqual(os.environ.get('MINIMAX_API_KEY'), 'test-env-key')
+
+
+class TestMiniMaxFactory(unittest.TestCase):
+    """Test that ModelFactory correctly routes MiniMax models."""
+
+    @patch('models.model.OpenAI')
+    def test_factory_creates_minimax_m27(self, mock_openai_cls):
+        """ModelFactory should create MiniMax instance for MiniMax-M2.7."""
+        mock_openai_cls.return_value = MagicMock()
+        from models.factory import ModelFactory
+        from models.minimax import MiniMax
+        model = ModelFactory.create_model('MiniMax-M2.7', '', 'key', 'ctx')
+        self.assertIsInstance(model, MiniMax)
+
+    @patch('models.model.OpenAI')
+    def test_factory_creates_minimax_m25_highspeed(self, mock_openai_cls):
+        """ModelFactory should create MiniMax instance for MiniMax-M2.5-highspeed."""
+        mock_openai_cls.return_value = MagicMock()
+        from models.factory import ModelFactory
+        from models.minimax import MiniMax
+        model = ModelFactory.create_model('MiniMax-M2.5-highspeed', '', 'key', 'ctx')
+        self.assertIsInstance(model, MiniMax)
+
+    @patch('models.model.OpenAI')
+    def test_factory_creates_minimax_m25(self, mock_openai_cls):
+        """ModelFactory should create MiniMax instance for MiniMax-M2.5."""
+        mock_openai_cls.return_value = MagicMock()
+        from models.factory import ModelFactory
+        from models.minimax import MiniMax
+        model = ModelFactory.create_model('MiniMax-M2.5', '', 'key', 'ctx')
+        self.assertIsInstance(model, MiniMax)
+
+    @patch('models.model.OpenAI')
+    def test_factory_non_minimax_not_minimax(self, mock_openai_cls):
+        """ModelFactory should not create MiniMax for non-MiniMax model names."""
+        mock_openai_cls.return_value = MagicMock()
+        from models.factory import ModelFactory
+        from models.minimax import MiniMax
+        model = ModelFactory.create_model('gpt-4-vision-preview', '', 'key', 'ctx')
+        self.assertNotIsInstance(model, MiniMax)
+
+
+class TestMiniMaxGetInstructions(unittest.TestCase):
+    """Test the full get_instructions_for_objective flow."""
+
+    def test_get_instructions_full_flow(self):
+        """get_instructions_for_objective should return parsed JSON from LLM response."""
+        mock_screen = MagicMock()
+        mock_screen.return_value.get_screenshot_in_base64.return_value = 'fakebase64'
+        _mock_screen_module.Screen = mock_screen
+
+        with patch('models.model.OpenAI') as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+
+            expected = {
+                'steps': [
+                    {
+                        'function': 'click',
+                        'parameters': {'x': 500, 'y': 300},
+                        'human_readable_justification': 'Click on Chrome icon'
+                    }
+                ],
+                'done': None
+            }
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = json.dumps(expected)
+            mock_client.chat.completions.create.return_value = mock_response
+
+            from models.minimax import MiniMax
+            model = MiniMax('MiniMax-M2.7', '', 'test-key', 'You are a helpful assistant.')
+            result = model.get_instructions_for_objective('Open Chrome', 0)
+
+            self.assertEqual(result['steps'][0]['function'], 'click')
+            self.assertIsNone(result['done'])
+
+        _mock_screen_module.Screen = MagicMock()
+
+    def test_get_instructions_done_state(self):
+        """Should correctly handle done state responses."""
+        mock_screen = MagicMock()
+        mock_screen.return_value.get_screenshot_in_base64.return_value = 'fakebase64'
+        _mock_screen_module.Screen = mock_screen
+
+        with patch('models.model.OpenAI') as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+
+            expected = {'steps': [], 'done': 'Chrome is already open.'}
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = json.dumps(expected)
+            mock_client.chat.completions.create.return_value = mock_response
+
+            from models.minimax import MiniMax
+            model = MiniMax('MiniMax-M2.7', '', 'test-key', 'ctx')
+            result = model.get_instructions_for_objective('Open Chrome', 1)
+
+            self.assertEqual(result['steps'], [])
+            self.assertEqual(result['done'], 'Chrome is already open.')
+
+        _mock_screen_module.Screen = MagicMock()
+
+    def test_get_instructions_with_think_tags(self):
+        """Should strip think tags in full flow."""
+        mock_screen = MagicMock()
+        mock_screen.return_value.get_screenshot_in_base64.return_value = 'fakebase64'
+        _mock_screen_module.Screen = mock_screen
+
+        with patch('models.model.OpenAI') as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = (
+                '<think>reasoning here</think>\n'
+                '{"steps": [{"function": "write", "parameters": {"string": "hello"}}], "done": null}'
+            )
+            mock_client.chat.completions.create.return_value = mock_response
+
+            from models.minimax import MiniMax
+            model = MiniMax('MiniMax-M2.5-highspeed', '', 'test-key', 'ctx')
+            result = model.get_instructions_for_objective('Type hello', 0)
+
+            self.assertEqual(result['steps'][0]['function'], 'write')
+
+        _mock_screen_module.Screen = MagicMock()
+
+
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    def setUp(self):
+        self.api_key = os.environ.get('MINIMAX_API_KEY', '')
+        if not self.api_key:
+            self.skipTest('MINIMAX_API_KEY not set')
+
+    def test_real_api_connection(self):
+        """Test that MiniMax API accepts a basic chat completion request."""
+        client = OpenAI(api_key=self.api_key, base_url='https://api.minimax.io/v1/')
+        response = client.chat.completions.create(
+            model='MiniMax-M2.7',
+            messages=[{'role': 'user', 'content': 'Say hello in one word.'}],
+            max_tokens=10,
+        )
+        self.assertTrue(len(response.choices) > 0)
+        self.assertTrue(len(response.choices[0].message.content) > 0)
+
+    def test_real_api_m25_highspeed(self):
+        """Test MiniMax-M2.5-highspeed model connectivity."""
+        client = OpenAI(api_key=self.api_key, base_url='https://api.minimax.io/v1/')
+        response = client.chat.completions.create(
+            model='MiniMax-M2.5-highspeed',
+            messages=[{'role': 'user', 'content': 'Reply OK.'}],
+            max_tokens=5,
+        )
+        self.assertTrue(len(response.choices) > 0)
+
+    def test_real_api_json_response(self):
+        """Test that MiniMax returns a response containing valid JSON."""
+        client = OpenAI(api_key=self.api_key, base_url='https://api.minimax.io/v1/')
+        response = client.chat.completions.create(
+            model='MiniMax-M2.7',
+            messages=[{
+                'role': 'user',
+                'content': 'Respond with exactly this JSON and nothing else: {"steps": [], "done": "ok"}'
+            }],
+            max_tokens=50,
+        )
+        content = response.choices[0].message.content.strip()
+        start = content.find('{')
+        if start >= 0:
+            # Use raw_decode to parse just the first JSON object
+            parsed, _ = json.JSONDecoder().raw_decode(content[start:])
+            self.assertIn('done', parsed)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com/) as a first-class LLM provider alongside OpenAI and Gemini. MiniMax offers powerful vision-capable models via an OpenAI-compatible API.

### Changes
- **`app/models/minimax.py`**: New `MiniMax` model class extending `Model` base, using `chat.completions.create` with:
  - Automatic base URL routing to `https://api.minimax.io/v1/`
  - `MINIMAX_API_KEY` environment variable auto-detection
  - Temperature clamping within MiniMax's accepted range
  - Think-tag stripping for reasoning models (M2.5+)
- **`app/models/factory.py`**: Route `MiniMax-*` model names to the `MiniMax` class
- **`app/ui.py`**: Add MiniMax-M2.7 and MiniMax-M2.5-highspeed radio buttons in Advanced Settings; update API key label
- **`README.md`**: Add MiniMax setup instructions section
- **`tests/test_minimax.py`**: 25 unit tests + 3 integration tests covering:
  - Base URL routing (default, custom, OpenAI override)
  - API key handling (explicit + env var fallback)
  - Request formatting with vision content
  - Temperature clamping and max_tokens
  - JSON response parsing (clean, extra text, think tags, malformed)
  - Factory routing for all MiniMax model variants
  - Full get_instructions_for_objective flow
  - Live API connectivity (M2.7 + M2.5-highspeed)

### Models Added
| Model | Context Window | Notes |
|-------|---------------|-------|
| MiniMax-M2.7 | 1M tokens | Latest flagship model |
| MiniMax-M2.5-highspeed | 204K tokens | Fast inference |

### How It Works
Users can select MiniMax models from **Settings → Advanced Settings** radio buttons. The base URL is automatically configured — users just need to enter their MiniMax API key in the Settings window (or set `MINIMAX_API_KEY` env var).

## Test Plan
- [x] All 25 unit tests pass
- [x] All 3 integration tests pass (live MiniMax API)
- [x] Factory correctly routes MiniMax-* model names
- [x] Non-MiniMax models unaffected (GPT4v fallback preserved)
- [ ] Manual test: select MiniMax-M2.7 in UI, enter API key, verify computer control works