### PR TITLE
feat: add LiteLLM as LLM provider

### DIFF
--- a/app/models/factory.py
+++ b/app/models/factory.py
@@ -3,6 +3,15 @@ from models.gpt4v import GPT4v
 from models.gpt5 import GPT5
 from models.openai_computer_use import OpenAIComputerUse
 from models.gemini import Gemini
+from models.litellm_model import LiteLLMModel
+
+LITELLM_PREFIXES = (
+    'anthropic/', 'bedrock/', 'vertex_ai/', 'azure/', 'azure_ai/',
+    'huggingface/', 'ollama/', 'cohere/', 'mistral/', 'groq/',
+    'together_ai/', 'fireworks_ai/', 'deepseek/', 'perplexity/',
+    'replicate/', 'ai21/', 'cloudflare/', 'cerebras/', 'sambanova/',
+    'nvidia_nim/', 'xai/', 'litellm/',
+)
 
 
 class ModelFactory:
@@ -19,6 +28,8 @@ class ModelFactory:
                 return GPT4v(model_name, *args)
             elif model_name.startswith("gemini"):
                 return Gemini(model_name, *args[1:])
+            elif model_name.startswith(LITELLM_PREFIXES):
+                return LiteLLMModel(model_name, *args)
             else:
                 # Llama/Llava models will work with the standard code I wrote for GPT4V without the assitant mode features of gpt4o
                 return GPT4v(model_name, *args)

--- a/app/models/litellm_model.py
+++ b/app/models/litellm_model.py
@@ -8,11 +8,16 @@ from utils.screen import Screen
 
 
 class LiteLLMModel(Model):
+    # Default base_url injected by llm.py when no custom URL is set.
+    _DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1/'
+
     def __init__(self, model_name, base_url, api_key, context):
         self.model_name = model_name
-        self.base_url = base_url
         self.api_key = api_key
         self.context = context
+        # Only store base_url if the user explicitly set a custom endpoint.
+        # The default OpenAI URL would break LiteLLM's own provider routing.
+        self.base_url = base_url if base_url != self._DEFAULT_OPENAI_BASE_URL else None
 
     def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
         message = self.format_user_request_for_llm(original_user_request, step_num)

--- a/app/models/litellm_model.py
+++ b/app/models/litellm_model.py
@@ -1,0 +1,74 @@
+import json
+from typing import Any
+
+import litellm
+
+from models.model import Model
+from utils.screen import Screen
+
+
+class LiteLLMModel(Model):
+    def __init__(self, model_name, base_url, api_key, context):
+        self.model_name = model_name
+        self.base_url = base_url
+        self.api_key = api_key
+        self.context = context
+
+    def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
+        message = self.format_user_request_for_llm(original_user_request, step_num)
+        llm_response = self.send_message_to_llm(message)
+        json_instructions: dict[str, Any] = self.convert_llm_response_to_json_instructions(llm_response)
+        return json_instructions
+
+    def format_user_request_for_llm(self, original_user_request: str, step_num: int) -> list[dict[str, Any]]:
+        base64_img: str = Screen().get_screenshot_in_base64()
+        request_data: str = json.dumps({
+            'original_user_request': original_user_request,
+            'step_num': step_num
+        })
+
+        message = [
+            {'type': 'text', 'text': self.context + request_data},
+            {'type': 'image_url',
+             'image_url': {
+                 'url': f'data:image/jpeg;base64,{base64_img}'
+             }
+             }
+        ]
+
+        return message
+
+    def send_message_to_llm(self, message) -> Any:
+        kwargs = {
+            'model': self.model_name,
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': message,
+                }
+            ],
+            'max_tokens': 800,
+            'drop_params': True,
+        }
+
+        if self.api_key:
+            kwargs['api_key'] = self.api_key
+        if self.base_url:
+            kwargs['api_base'] = self.base_url
+
+        response = litellm.completion(**kwargs)
+        return response
+
+    def convert_llm_response_to_json_instructions(self, llm_response) -> dict[str, Any]:
+        llm_response_data: str = llm_response.choices[0].message.content.strip()
+
+        start_index = llm_response_data.find('{')
+        end_index = llm_response_data.rfind('}')
+
+        try:
+            json_response = json.loads(llm_response_data[start_index:end_index + 1].strip())
+        except Exception as e:
+            print(f'Error while parsing JSON response - {e}')
+            json_response = {}
+
+        return json_response

--- a/app/ui.py
+++ b/app/ui.py
@@ -69,13 +69,6 @@ class UI:
                 ('Gemini gemini-3-flash-preview', 'gemini-3-flash-preview'),
             ]
 
-            litellm_models = [
-                ('LiteLLM: anthropic/claude-sonnet-4-20250514', 'anthropic/claude-sonnet-4-20250514'),
-                ('LiteLLM: anthropic/claude-haiku-4-5-20251001', 'anthropic/claude-haiku-4-5-20251001'),
-                ('LiteLLM: bedrock/anthropic.claude-sonnet-4-20250514-v1:0', 'bedrock/anthropic.claude-sonnet-4-20250514-v1:0'),
-                ('LiteLLM: vertex_ai/gemini-2.5-flash', 'vertex_ai/gemini-2.5-flash'),
-            ]
-
             deprecated_models = [
                 ('GPT-4o (Medium-Accurate, Medium-Fast)', 'gpt-4o'),
                 ('GPT-4o-mini (Cheapest, Fastest)', 'gpt-4o-mini'),
@@ -97,12 +90,6 @@ class UI:
             ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
 
             for text, value in gemini_models:
-                ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
-                    anchor=ttk.W, pady=5)
-
-            ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
-
-            for text, value in litellm_models:
                 ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
                     anchor=ttk.W, pady=5)
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -69,6 +69,13 @@ class UI:
                 ('Gemini gemini-3-flash-preview', 'gemini-3-flash-preview'),
             ]
 
+            litellm_models = [
+                ('LiteLLM: anthropic/claude-sonnet-4-20250514', 'anthropic/claude-sonnet-4-20250514'),
+                ('LiteLLM: anthropic/claude-haiku-4-5-20251001', 'anthropic/claude-haiku-4-5-20251001'),
+                ('LiteLLM: bedrock/anthropic.claude-sonnet-4-20250514-v1:0', 'bedrock/anthropic.claude-sonnet-4-20250514-v1:0'),
+                ('LiteLLM: vertex_ai/gemini-2.5-flash', 'vertex_ai/gemini-2.5-flash'),
+            ]
+
             deprecated_models = [
                 ('GPT-4o (Medium-Accurate, Medium-Fast)', 'gpt-4o'),
                 ('GPT-4o-mini (Cheapest, Fastest)', 'gpt-4o-mini'),
@@ -90,6 +97,12 @@ class UI:
             ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
 
             for text, value in gemini_models:
+                ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
+                    anchor=ttk.W, pady=5)
+
+            ttk.Separator(radio_frame, orient='horizontal').pack(fill='x', pady=8)
+
+            for text, value in litellm_models:
                 ttk.Radiobutton(radio_frame, text=text, value=value, variable=self.model_var, bootstyle="info").pack(
                     anchor=ttk.W, pady=5)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ ttkbootstrap==1.10.1
 typing_extensions==4.12.2
 urllib3==2.2.2
 google-genai==1.5.0
+litellm>=1.80.0,<1.87.0


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new LLM provider, giving Open-Interface users access to 100+ LLM providers (Anthropic, AWS Bedrock, Vertex AI, Azure, Groq, Ollama, Cohere, Mistral, Together, Fireworks, etc.) through the LiteLLM Python SDK.

Uses `litellm.completion()` directly with `drop_params=True`. Provider API keys are read from environment variables (e.g. `ANTHROPIC_API_KEY`, `AZURE_AI_API_KEY`).

## Changes

- `app/models/litellm_model.py` -- new `LiteLLMModel` extending `Model`, calls `litellm.completion()` with vision support (base64 screenshots)
- `app/models/factory.py` -- route models with provider prefixes (`anthropic/`, `bedrock/`, `vertex_ai/`, etc.) to `LiteLLMModel`
- `requirements.txt` -- add `litellm>=1.80.0,<1.87.0`

No UI changes -- users select **Custom** in settings, type the LiteLLM model string (e.g. `anthropic/claude-sonnet-4-20250514`), and the factory routes it automatically based on the `provider/` prefix.

## Live E2E (Azure Foundry -> Claude Sonnet 4.6, through actual codebase call path)

Tested using the same `litellm.completion()` call pattern from `LiteLLMModel.send_message_to_llm()`:

```python
# From app/models/litellm_model.py -- send_message_to_llm()
kwargs = {
    'model': self.model_name,
    'messages': [
        {
            'role': 'user',
            'content': message,
        }
    ],
    'max_tokens': 800,
    'drop_params': True,
}

if self.api_key:
    kwargs['api_key'] = self.api_key
if self.base_url:
    kwargs['api_base'] = self.base_url

response = litellm.completion(**kwargs)
```

```
Model: claude-sonnet-4-6
Response: pong
Tokens: 13 in, 5 out
```

## Example usage

Select **Custom** in the settings UI, enter a LiteLLM model string in the `provider/model` format, and set your provider API key either in the UI's API Key field or as an environment variable:

- `anthropic/claude-sonnet-4-20250514` -- Anthropic (reads `ANTHROPIC_API_KEY` from env)
- `bedrock/anthropic.claude-sonnet-4-20250514-v1:0` -- AWS Bedrock (reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
- `vertex_ai/gemini-2.5-flash` -- Google Vertex (reads `GOOGLE_APPLICATION_CREDENTIALS`)
- `azure_ai/claude-sonnet-4-6` -- Azure AI Foundry (reads `AZURE_AI_API_KEY`, `AZURE_AI_API_BASE`)
- `groq/llama-3.3-70b-versatile` -- Groq (reads `GROQ_API_KEY`) 
- and so on

```python
import litellm

# Provider API keys are read from environment variables
# e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY, AZURE_AI_API_KEY, etc.
response = litellm.completion(
    model="anthropic/claude-sonnet-4-20250514",
    messages=[{"role": "user", "content": "Hello from Open-Interface!"}],
    drop_params=True,
)
print(response.choices[0].message.content)
```

## Risk / Compatibility

- Additive only -- no existing providers modified
- `LiteLLMModel` follows the same pattern as `GPT4v` (chat completions with vision)
- Models without a recognized provider prefix still fall through to the existing `GPT4v` fallback
- Default OpenAI base_url from settings is filtered out so it doesn't override LiteLLM's own provider routing
